### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -212,10 +212,12 @@ const commands = {
                     return callback(null, _markdown);
                 }
 
+                //trigger link to oxford if throttle triggered
                 var moredefs = 0;
                 res.results.forEach(r => {
                     r.lexicalEntries.forEach(le => {
                         var newcategory = 1;
+                        var defentries = 0;
                         _markdown += `\n***${le.lexicalCategory.toUpperCase()}***\n`;
 
                         le.entries.forEach(e => {
@@ -224,16 +226,26 @@ const commands = {
                                 moredefs = 1;
                                 return;
                             }
+                            //used to ensure at least one definition per category is displayed
                             newcategory = 0;
 
-                            e.senses.forEach((s, i) => {
+                            e.senses.forEach((s) => {
                                 s.definitions.forEach(d => {
-                                    _markdown += `\n- **${i + 1}** ${d}  \n`;
+                                    defentries++;
+                                    //swap list types to ensure proper spacing between definitions
+                                    if (defentries % 2 === 1) {
+                                        _markdown += `- **${defentries}.** ${d}  \n`;
+                                    } else {
+                                        _markdown += `+ **${defentries}.** ${d}  \n`;
+                                    }
 
                                     if (s.subsenses) {
                                         s.subsenses.forEach((ss, j) => {
                                             ss.definitions.forEach(d => {
-                                                _markdown += `  - **${i + 1}.${j + 1}** ${d}\n`;
+                                                if (j <= 4) {
+                                                    _markdown += `  + **${defentries}.${j + 1}** ${d}\n`;
+                                                    moredefs = 1;
+                                                }
                                             });
                                         });
                                     }
@@ -242,7 +254,7 @@ const commands = {
                         });
                     });
                 });
-                
+
                 if (moredefs === 1) {
                     _markdown += `\n\n More definitions available via [url=https://en.oxforddictionaries.com/definition/${encodeURIComponent(args)}]Oxford Dictionary[/url]\n`;
                 }


### PR DESCRIPTION
Updated throttling. 
Ensure that at least 1 definition from each word type (verb, noun etc) is displayed.
Alter list types between + and - to ensure proper spacing.
Always increment main definition and only reset it upon new word type (verb, noun etc)
If throttling happens, link oxford dictionary for full reference